### PR TITLE
Fix tests.

### DIFF
--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
 		fileContent = fileContent.replace(/<inline.+?src=["']([^"']+?)["']\s*?\/>/g, function(matchedWord, src){
 			var ret = matchedWord;
 
-			if(isRemotePath(src) && !grunt.file.isPathAbsolute(src)){
+			if(isRemotePath(src) || !grunt.file.isPathAbsolute(src)){
 
 				var inlineFilePath = path.resolve( path.dirname(filepath), src );
 				grunt.log.writeln('inline >inline file，src = ' + src + ', 实际路径：'+inlineFilePath);

--- a/test/dist/styles/main.css
+++ b/test/dist/styles/main.css
@@ -1,0 +1,1 @@
+.main{border: none;}


### PR DESCRIPTION
Hey. Thanks for a useful grunt plugin.

I have a couple of patches, but before I send those pull requests, please consider this patch also. 

Clean checkout from this repo, npm install and grunt test returns this:

```
$ grunt test
Running "clean:tests" (clean) task

Running "inline:dist" (inline) task

inline任务开始！！

inline > 处理文件开始：test/dist/css.html
inline > inline stylesheet，href = styles/main.css?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css
>> inline > /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css 不存在！
inline > inline stylesheet，href = styles/main.css?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css
>> inline > /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css 不存在！
inline > 目标路径：tmp/css.html

inline > 处理文件结束：test/dist/css.html
inline > 处理文件开始：test/dist/css_greedy.html
inline > inline stylesheet，href = styles/main.css?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css
>> inline > /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css 不存在！
inline > inline stylesheet，href = styles/main.css?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css
>> inline > /Users/eirikmorland/github/grunt-inline/test/dist/styles/main.css 不存在！
inline > 目标路径：tmp/css_greedy.html

inline > 处理文件结束：test/dist/css_greedy.html
inline > 处理文件开始：test/dist/html.html
inline > 目标路径：tmp/html.html

inline > 处理文件结束：test/dist/html.html
inline > 处理文件开始：test/dist/html_greedy.html
inline > 目标路径：tmp/html_greedy.html

inline > 处理文件结束：test/dist/html_greedy.html
inline > 处理文件开始：test/dist/img.html
inline > inline img，src = img/icon.png?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/img/icon.png
inline > 目标路径：tmp/img.html

inline > 处理文件结束：test/dist/img.html
inline > 处理文件开始：test/dist/img_greedy.html
inline > inline img，src = img/icon.png?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/img/icon.png
inline > inline img，src = img/icon.png?__inline=true , 实际路径： /Users/eirikmorland/github/grunt-inline/test/dist/img/icon.png
inline > 目标路径：tmp/img_greedy.html

inline > 处理文件结束：test/dist/img_greedy.html
inline > 处理文件开始：test/dist/script.html
inline >inline script，src = js/export.js?__inline=true, 实际路径：/Users/eirikmorland/github/grunt-inline/test/dist/js/export.js
inline > 目标路径：tmp/script.html

inline > 处理文件结束：test/dist/script.html
inline > 处理文件开始：test/dist/script_greedy.html
inline >inline script，src = js/export.js?__inline=true, 实际路径：/Users/eirikmorland/github/grunt-inline/test/dist/js/export.js
inline >inline script，src = js/export.js?__inline=true, 实际路径：/Users/eirikmorland/github/grunt-inline/test/dist/js/export.js
inline > 目标路径：tmp/script_greedy.html

inline > 处理文件结束：test/dist/script_greedy.html

inline任务结束！！

Running "htmlmin:dist" (htmlmin) task
File tmp/css.min.html created.
File tmp/img.min.html created.
File tmp/html.min.html created.
File tmp/script.min.html created.
File tmp/css_greedy.min.html created.
File tmp/img_greedy.min.html created.
File tmp/html_greedy.min.html created.
File tmp/script_greedy.min.html created.

Running "nodeunit:tests" (nodeunit) task
Testing greedy_test.jsF
>> inline
>> Message: Should compile two link target without newline characters
>> Error: '<!DOCTYPE html><html><head><title>test</title><style>.main{border: none;}</style><style>.main{border: none;}</style></head><body></body></html>' == '<!DOCTYPE html><html><head><title>test</title><link href="styles/main.css?__inline=true" rel="stylesheet"><link href="styles/main.css?__inline=true" rel="stylesheet"></head><body></body></html>'
>> at assertFileEquality (test/greedy_test.js:19:10)
>> at Object.exports.inline (test/greedy_test.js:32:5)

>> inline
>> Message: Should compile two inline target without newline characters
>> Error: '<!DOCTYPE html><html><head><title>test</title></head><body><p>test</p><p>test</p></body></html>' == '<!DOCTYPE html><html><head><title>test</title></head><body><inline src="html/test.html"><inline src="html/test.html"></body></html>'
>> at assertFileEquality (test/greedy_test.js:19:10)
>> at Object.exports.inline (test/greedy_test.js:37:5)

Testing inline_test.jsF
>> inline
>> Message: Should compile css inline
>> Error: '<!DOCTYPE html><html><head><title>test</title><style>.main{border: none;}</style><style>.main{border: none;}</style></head><body></body></html>' == '<!DOCTYPE html><html><head><title>test</title><link href="styles/main.css?__inline=true" rel="stylesheet"><link href="styles/main.css?__inline=true" rel="stylesheet"></head><body></body></html>'
>> at assertFileEquality (test/inline_test.js:19:10)
>> at Object.exports.inline (test/inline_test.js:27:5)

>> inline
>> Message: Should compile html inline
>> Error: '<!DOCTYPE html><html><head><title>test</title></head><body><p>test</p></body></html>' == '<!DOCTYPE html><html><head><title>test</title></head><body><inline src="html/test.html"></body></html>'
>> at assertFileEquality (test/inline_test.js:19:10)
>> at Object.exports.inline (test/inline_test.js:37:5)

Warning: 4/8 assertions failed (12ms) Use --force to continue.

Aborted due to warnings.
```

These broken tests were introduced by commits dfff2e1f3dd1048be0f185a8e0163535a20b8092 and d5df1be570bdc4fdc115c83c3916a0afa0ab06c3

Attached patch fixes all tests.
