### PR TITLE
Prevents match with base 64 images

### DIFF
--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -127,7 +127,7 @@ module.exports = function(grunt) {
 			grunt.log.debug('ret = : ' + ret +'\n');
 			
 			return ret;	
-		}).replace(/<img.+?src=["']([^"']+?)["'].*?\/?\s*?>/g, function(matchedWord, src){
+		}).replace(/<img.+?src=["']([^"':]+?)["'].*?\/?\s*?>/g, function(matchedWord, src){
 			var	ret = matchedWord;
 			
 			if(!grunt.file.isPathAbsolute(src) && src.indexOf(options.tag)!=-1){


### PR DESCRIPTION
Small change, current regex will match already inlined images. All base64 images contain colons, no files contain colons
