### PR TITLE
修复一个正则匹配错误

### DIFF
--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
 	        filepath = filepath.replace(/[^\/]+\//, relativeTo);
 	    }
 
-		fileContent = fileContent.replace(/<inline.+?src=["']([^"']+?)["']\s*?\/>/g, function(matchedWord, src){
+		fileContent = fileContent.replace(/<inline[^>]+?src=["']([^"']+?)["']\s*?\/>/g, function(matchedWord, src){
 			var ret = matchedWord;
 
 			if(isRemotePath(src) || !grunt.file.isPathAbsolute(src)){
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
 							}
 							return _ret;
 						}
-						ret = ret.replace(/(<script.+?src=["'])([^"']+?)(["'].*?><\/script>)/g,_addMore);
+						ret = ret.replace(/(<script[^>]+?src=["'])([^"']+?)(["'].*?><\/script>)/g,_addMore);
 					}
 				}else{
 					grunt.log.error("Couldn't find " + inlineFilePath + '!');
@@ -101,7 +101,7 @@ module.exports = function(grunt) {
 			}
 
 			return ret;
-		}).replace(/<script.+?src=["']([^"']+?)["'].*?>\s*<\/script>/g, function(matchedWord, src){
+		}).replace(/<script[^>]+?src=["']([^"']+?)["'].*?>\s*<\/script>/g, function(matchedWord, src){
 			var ret = matchedWord;
 
 			if(!isRemotePath(src) && src.indexOf(options.tag)!=-1){
@@ -118,7 +118,7 @@ module.exports = function(grunt) {
 
 			return ret;
 
-		}).replace(/<link.+?href=["']([^"']+?)["'].*?\/?>/g, function(matchedWord, src){
+		}).replace(/<link[^>]+?href=["']([^"']+?)["'].*?\/?>/g, function(matchedWord, src){
 			var ret = matchedWord;
 
 			if(!isRemotePath(src) && src.indexOf(options.tag)!=-1){
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
 			grunt.log.debug('ret = : ' + ret +'\n');
 
 			return ret;
-		}).replace(/<img.+?src=["']([^"':]+?)["'].*?\/?\s*?>/g, function(matchedWord, src){
+		}).replace(/<img[^>]+?src=["']([^"':]+?)["'].*?\/?\s*?>/g, function(matchedWord, src){
 			var	ret = matchedWord;
 
 			if(!grunt.file.isPathAbsolute(src) && src.indexOf(options.tag)!=-1){

--- a/test/dist/script_greedy.html
+++ b/test/dist/script_greedy.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>test</title>
-	<script src="js/export.js?__inline=true"></script><script src="js/export.js?__inline=true"></script>
+	<script>console.log('yo')</script><script src="js/export.js?__inline=true"></script><script src="js/export.js?__inline=true"></script>
 </head>
 <body>
 </body>

--- a/test/expected/script_greedy.min.html
+++ b/test/expected/script_greedy.min.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>test</title><script>console.log('test');</script><script>console.log('test');</script></head><body></body></html>
+<!DOCTYPE html><html><head><title>test</title><script>console.log('yo')</script><script>console.log('test');</script><script>console.log('test');</script></head><body></body></html>


### PR DESCRIPTION
如下 html 代码

``` html
<script>console.log('yo')</script><script src="js/export.js?__inline=true"></script>
```

原有的正则表达式会匹配整行，而导致第一个 script 标签被错误地删除。
现在使用`[^>]+?`代替`.+?`保证只匹配`>`符号之前的内容。
