### PR TITLE
Update inline.js

### DIFF
--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -218,7 +218,7 @@ module.exports = function(grunt) {
 
 		fileContent = fileContent.replace(/url\(["']*([^)'"]+)["']*\)/g, function(matchedWord, imgUrl){
 			var newUrl = imgUrl;
-			var flag = !!imgUrl.match(/\?__inline/);	// urls like "img/bg.png?__inline" will be transformed to base64
+			var flag = imgUrl.indexOf(options.tag)!=-1;	// urls like "img/bg.png?__inline" and "img/bg.__inline.png" will be transformed to base64
 			grunt.log.debug('flag:'+flag);
 			if(isBase64Path(imgUrl) || isRemotePath(imgUrl)){
 				return matchedWord;


### PR DESCRIPTION
修改cssInlineToHtml中判断tag的正则，改为和其他方法中一样使用indexOf判断，以支持文件名称中包含tag的使用方式